### PR TITLE
Acceleration of fri::commit

### DIFF
--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -73,6 +73,8 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2DitParallel {
         par_dit_layer_rev(&mut mat, mid, &twiddles_inv);
         // We skip the final bit-reversal, since the next FFT expects bit-reversed input.
 
+        return mat.bit_reverse_rows();
+
         // Rescale coefficients in two ways:
         // - divide by height (since we're doing an inverse DFT)
         // - multiply by powers of the coset shift (see default coset LDE impl for an explanation)
@@ -85,7 +87,6 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2DitParallel {
             // reverse_bits because mat is encoded in bit-reversed order
             mat.scale_row(reverse_bits(row, h), weight);
         }
-
         mat = mat.bit_reversed_zero_pad(added_bits);
 
         let h = mat.height();

--- a/dft/src/radix_2_dit_parallel.rs
+++ b/dft/src/radix_2_dit_parallel.rs
@@ -73,8 +73,6 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2DitParallel {
         par_dit_layer_rev(&mut mat, mid, &twiddles_inv);
         // We skip the final bit-reversal, since the next FFT expects bit-reversed input.
 
-        return mat.bit_reverse_rows();
-
         // Rescale coefficients in two ways:
         // - divide by height (since we're doing an inverse DFT)
         // - multiply by powers of the coset shift (see default coset LDE impl for an explanation)
@@ -87,6 +85,7 @@ impl<F: TwoAdicField> TwoAdicSubgroupDft<F> for Radix2DitParallel {
             // reverse_bits because mat is encoded in bit-reversed order
             mat.scale_row(reverse_bits(row, h), weight);
         }
+
         mat = mat.bit_reversed_zero_pad(added_bits);
 
         let h = mat.height();

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -13,14 +13,13 @@ p3-interpolation = { path = "../interpolation" }
 p3-matrix = { path = "../matrix" }
 p3-maybe-rayon = { path = "../maybe-rayon" }
 p3-util = { path = "../util" }
+p3-baby-bear = { path = "../baby-bear" }
 itertools = "0.12.0"
 tracing = "0.1.37"
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
-icicle-cuda-runtime = { path = "../../icicle/wrappers/rust/icicle-cuda-runtime" }
-icicle-babybear = { path = "../../icicle/wrappers/rust/icicle-fields/icicle-babybear" }
-icicle-core = { path = "../../icicle/wrappers/rust/icicle-core" }
-p3-baby-bear = { path = "../baby-bear" }
-
+icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v2.3.0" }
+icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v2.3.0" }
+icicle-babybear = { git = "https://github.com/ingonyama-zk/icicle.git", tag = "v2.3.0" }
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -16,6 +16,11 @@ p3-util = { path = "../util" }
 itertools = "0.12.0"
 tracing = "0.1.37"
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+icicle-cuda-runtime = { path = "../../icicle/wrappers/rust/icicle-cuda-runtime" }
+icicle-babybear = { path = "../../icicle/wrappers/rust/icicle-fields/icicle-babybear" }
+icicle-core = { path = "../../icicle/wrappers/rust/icicle-core" }
+p3-baby-bear = { path = "../baby-bear" }
+
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }

--- a/fri/src/lib.rs
+++ b/fri/src/lib.rs
@@ -1,6 +1,7 @@
 //! An implementation of the FRI low-degree test (LDT).
 
-#![no_std]
+// I wanted macros, so I commented this out
+//#![no_std]
 
 extern crate alloc;
 

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -167,8 +167,6 @@ where
                 let mut matrix_p3 = RowMajorMatrix::new(scalars_p3, evals.width()).bit_reverse_rows().to_row_major_matrix();
 
                 // PART TWO - scale up
-                println!("p3 - size {} log_n {} matrix_p3.height {} matrix_p3.len {} matrix_p3.width {}", size, log_n, matrix_p3.height(), matrix_p3.values.len(), matrix_p3.width());
-            
                 let h = matrix_p3.height();
                 let h_inv = Val::from_canonical_usize(h).inverse();
 
@@ -188,7 +186,7 @@ where
                 let log_n = log2_strict_usize(matrix_p3.height());
                 let ctx = DeviceContext::default();
                 let size = 1 << log_n;
-                let plonky3_rou = Val::two_adic_generator(log_n+self.fri.log_blowup);
+                let plonky3_rou = Val::two_adic_generator(log_n);
                 initialize_domain(ScalarField::from([plonky3_rou.as_canonical_u32()]), &ntt_cfg.ctx, true).unwrap();
 
                 ntt_results = DeviceVec::<ScalarField>::cuda_malloc(matrix_p3.values.len()).unwrap();
@@ -198,7 +196,7 @@ where
                 let mut ntt_cfg2: NTTConfig<'_, ScalarField> = NTTConfig::default();
                 ntt_cfg2.batch_size = matrix_p3.width() as i32;
                 ntt_cfg2.columns_batch = true;
-
+                println!("p3 - size {} log_n {} matrix_p3.height {} matrix_p3.len {} matrix_p3.width {}", size, log_n, matrix_p3.height(), matrix_p3.values.len(), matrix_p3.width());
                 ntt::ntt(HostSlice::from_mut_slice(&mut actual_scalars[..]), NTTDir::kForward, &ntt_cfg2, &mut ntt_results[..]).unwrap();
 
                 ntt_cfg2.ctx.stream.synchronize().unwrap();

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -9,7 +9,7 @@ use p3_commit::{Mmcs, OpenedValues, Pcs, PolynomialSpace, TwoAdicMultiplicativeC
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::{
     batch_multiplicative_inverse, cyclic_subgroup_coset_known_order, AbstractField, ExtensionField,
-    Field, PackedValue, TwoAdicField,
+    Field, PackedValue, TwoAdicField, Powers, PrimeField32
 };
 use p3_interpolation::interpolate_coset;
 use p3_matrix::bitrev::{BitReversableMatrix, BitReversalPerm};
@@ -17,19 +17,16 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::{Dimensions, Matrix};
 use p3_maybe_rayon::prelude::*;
 use p3_util::linear_map::LinearMap;
-use p3_util::{log2_strict_usize, reverse_bits_len, reverse_slice_index_bits, VecExt};
+use p3_util::{log2_strict_usize, reverse_bits_len, reverse_slice_index_bits, reverse_bits, VecExt};
 use serde::{Deserialize, Serialize};
 use tracing::{info_span, instrument};
 
-use p3_field::PrimeField32;
-use p3_util::reverse_bits;
 use icicle_babybear::field::ScalarField;
-use icicle_cuda_runtime::{device_context::DeviceContext, stream::CudaStream,memory::HostSlice, memory::DeviceVec};
+use icicle_cuda_runtime::{memory::HostSlice, memory::DeviceVec};
 use icicle_core::{
-    ntt::{self, initialize_domain, NTTConfig, NTTDir, NttAlgorithm, Ordering, release_domain},
-    traits::{FieldImpl},
+    ntt::{self, initialize_domain, NTTConfig, NTTDir, release_domain},
+    traits::FieldImpl,
 };
-use p3_field::{Powers};
 use crate::verifier::{self, FriError};
 use crate::{prover, FriConfig, FriProof};
 
@@ -115,115 +112,17 @@ where
         &self,
         evaluations: Vec<(Self::Domain, RowMajorMatrix<Val>)>,
     ) -> (Self::Commitment, Self::ProverData) {
-        let ldes: Vec<_> = evaluations.clone()
+        let ldes: Vec<_> = evaluations
             .into_iter()
             .map(|(domain, evals)| {
                 assert_eq!(domain.size(), evals.height());
-                let log_n = log2_strict_usize(domain.size());
-                assert!(log_n <= self.log_n);
-                let shift = Val::generator() / domain.shift;
-                // Commit to the bit-reversed LDE.
-                self.dft
-                    .coset_lde_batch(evals, self.fri.log_blowup, shift)
-                    .bit_reverse_rows()
-                    .to_row_major_matrix()
-            })
-            .collect();
-
-        let ldes_gpu: Vec<_> = evaluations
-            .into_iter()
-            .map(|(domain, evals)| {
-                assert_eq!(domain.size(), evals.height());
-                // PART ONE - inverse FFT
-
-                let shift = Val::generator() / domain.shift;
-                let log_n = log2_strict_usize(domain.size());
-
-                let ctx = DeviceContext::default(); 
-                let size = 1 << log_n;
-                let plonky3_rou = Val::two_adic_generator(log_n).inverse();
-                println!("p1 - size {} log_n {} evals.height {} evals.len {} evals.width {} shift {}", size, log_n, evals.height(), evals.values.len(), evals.width(), shift);
-                initialize_domain(ScalarField::from([plonky3_rou.as_canonical_u32()]), &ctx, true).unwrap();
-
-                let mut ntt_results = DeviceVec::<ScalarField>::cuda_malloc(evals.values.len()).unwrap();
-                let mut host_ntt_results = vec![ScalarField::zero(); evals.values.len()];
-
-                let mut actual_scalars : Vec<ScalarField> = evals.values.iter().map(|x| ScalarField::from_u32((*x).as_canonical_u32())).collect();
-
-                let mut ntt_cfg: NTTConfig<'_, ScalarField> = NTTConfig::default();
-                ntt_cfg.batch_size = evals.width() as i32;
-                ntt_cfg.columns_batch = true;
     
-                ntt::ntt(HostSlice::from_mut_slice(&mut actual_scalars[..]), NTTDir::kForward, &ntt_cfg, &mut ntt_results[..]).unwrap();
-
-                ntt_cfg.ctx.stream.synchronize().unwrap();
-                ntt_results
-                    .copy_to_host(HostSlice::from_mut_slice(&mut host_ntt_results[..]))
-                    .unwrap();
-                let mut scalars_p3: Vec<Val> = host_ntt_results
-                    .iter()
-                    .map(|x| Val::from_wrapped_u32(Into::<[u32; 1]>::into(*x)[0]))
-                    .collect();
-                let mut matrix_p3 = RowMajorMatrix::new(scalars_p3, evals.width()).bit_reverse_rows().to_row_major_matrix();
-
-                // PART TWO - scale up
-                let h = matrix_p3.height();
-                let h_inv = Val::from_canonical_usize(h).inverse();
-
-                let weights = Powers {
-                    base: shift,
-                    current: h_inv,
-                }
-                .take(h);
-                for (row, weight) in weights.enumerate() {
-                    // reverse_bits because mat is encoded in bit-reversed order
-                    matrix_p3.scale_row(reverse_bits(row, h), weight);
-                }
-
-                matrix_p3 = matrix_p3.bit_reversed_zero_pad(self.fri.log_blowup).bit_reverse_rows().to_row_major_matrix();
-                // PART THREE - forward FFT
-                release_domain::<ScalarField>(&ntt_cfg.ctx).unwrap(); 
-                let log_n = log2_strict_usize(matrix_p3.height());
-                let ctx = DeviceContext::default();
-                let size = 1 << log_n;
-                let plonky3_rou = Val::two_adic_generator(log_n);
-            
-                let mut ntt_cfg2: NTTConfig<'_, ScalarField> = NTTConfig::default();
-                ntt_cfg2.batch_size = matrix_p3.width() as i32;
-                ntt_cfg2.columns_batch = true;
-                initialize_domain(ScalarField::from([plonky3_rou.as_canonical_u32()]), &ntt_cfg2.ctx, true).unwrap();
-
-                ntt_results = DeviceVec::<ScalarField>::cuda_malloc(matrix_p3.values.len()).unwrap();
-                host_ntt_results = vec![ScalarField::zero(); matrix_p3.values.len()];
-                actual_scalars = matrix_p3.values.iter().map(|x| ScalarField::from_u32((*x).as_canonical_u32())).collect();
-                println!("config {:?}", ntt_cfg2);
-                println!("p3 - size {} log_n {} matrix_p3.height {} matrix_p3.len {} matrix_p3.width {}", size, log_n, matrix_p3.height(), matrix_p3.values.len(), matrix_p3.width());
-                ntt::ntt(HostSlice::from_mut_slice(&mut actual_scalars[..]), NTTDir::kForward, &ntt_cfg2, &mut ntt_results[..]).unwrap();
-
-                ntt_cfg2.ctx.stream.synchronize().unwrap();
-                ntt_results
-                    .copy_to_host(HostSlice::from_mut_slice(&mut host_ntt_results[..]))
-                    .unwrap();
-                scalars_p3 = host_ntt_results
-                    .iter()
-                    .map(|x| Val::from_wrapped_u32(Into::<[u32; 1]>::into(*x)[0]))
-                    .collect();
-                matrix_p3 = RowMajorMatrix::new(scalars_p3, matrix_p3.width());
-                release_domain::<ScalarField>(&ntt_cfg2.ctx).unwrap();
-                matrix_p3.bit_reverse_rows().to_row_major_matrix()
+                let matrix_p3 = inverse_fft::<Val>(domain.size(), &evals);
+                let matrix_p3 = scale_up::<Val>(&matrix_p3, Val::generator() / domain.shift, self.fri.log_blowup);
+                forward_fft::<Val>(matrix_p3)
             })
             .collect();
-        println!("First several values LDE {:?}", &ldes[0].values[0..10]);
-        println!("First several values LDE_GPU {:?}", &ldes_gpu[0].values[0..10]);
-        for index in 0..(ldes.len()-1) {
-            for i in 0..(ldes[index].values.len()) {
-                //println!("Processing {} at {}", index, i);
-                let correct  = ldes[index].values[i];
-                let gpu = ldes_gpu[index].values[i];
-                assert_eq!(correct, gpu);
-            }
-        }
-        //assert_eq!(ldes[0].values, ldes_gpu[0].values);
+    
         self.mmcs.commit(ldes)
     }
 
@@ -618,6 +517,97 @@ fn transpose_vec<T>(v: Vec<Vec<T>>) -> Vec<Vec<T>> {
         .collect()
 }
 
+
+fn inverse_fft<Val>(domain_size: usize, evals: &RowMajorMatrix<Val>) -> RowMajorMatrix<Val> 
+where 
+    Val: TwoAdicField + PrimeField32,
+{
+    let log_n = log2_strict_usize(domain_size);
+    let size = 1 << log_n;
+    let plonky3_rou = Val::two_adic_generator(log_n).inverse();
+    //println!("p1 - size {} log_n {} evals.height {} evals.len {} evals.width {}", size, log_n, evals.height(), evals.values.len(), evals.width());
+
+    let mut ntt_cfg: NTTConfig<'_, ScalarField> = NTTConfig::default();
+    ntt_cfg.batch_size = evals.width() as i32;
+    ntt_cfg.columns_batch = true;
+
+    initialize_domain(ScalarField::from([plonky3_rou.as_canonical_u32()]), &ntt_cfg.ctx, true).unwrap();
+
+    let mut ntt_results = DeviceVec::<ScalarField>::cuda_malloc(evals.values.len()).unwrap();
+    let mut host_ntt_results = vec![ScalarField::zero(); evals.values.len()];
+    let mut actual_scalars: Vec<ScalarField> = evals.values.iter().map(|x| ScalarField::from_u32((*x).as_canonical_u32())).collect();
+
+    ntt::ntt(HostSlice::from_mut_slice(&mut actual_scalars[..]), NTTDir::kForward, &ntt_cfg, &mut ntt_results[..]).unwrap();
+
+    ntt_cfg.ctx.stream.synchronize().unwrap();
+    ntt_results
+        .copy_to_host(HostSlice::from_mut_slice(&mut host_ntt_results[..]))
+        .unwrap();
+    let scalars_p3: Vec<Val> = host_ntt_results
+        .iter()
+        .map(|x| Val::from_wrapped_u32(Into::<[u32; 1]>::into(*x)[0]))
+        .collect();
+    let matrix_p3 = RowMajorMatrix::new(scalars_p3, evals.width()).bit_reverse_rows().to_row_major_matrix();
+    release_domain::<ScalarField>(&ntt_cfg.ctx).unwrap();
+
+    matrix_p3
+}
+
+fn scale_up<Val>(matrix: &RowMajorMatrix<Val>, shift: Val, blowup: usize) -> RowMajorMatrix<Val> 
+where 
+    Val: TwoAdicField + PrimeField32,
+{
+    let h = matrix.height();
+    let h_inv = Val::from_canonical_usize(h).inverse();
+
+    let weights = Powers {
+        base: shift,
+        current: h_inv,
+    }
+    .take(h);
+    let mut matrix_p3 = matrix.clone();
+    for (row, weight) in weights.enumerate() {
+        matrix_p3.scale_row(reverse_bits(row, h), weight);
+    }
+
+    matrix_p3.bit_reversed_zero_pad(blowup).bit_reverse_rows().to_row_major_matrix()
+}
+
+fn forward_fft<Val>(mut matrix: RowMajorMatrix<Val>) -> RowMajorMatrix<Val> 
+where 
+    Val: TwoAdicField + PrimeField32,
+{
+    let log_n = log2_strict_usize(matrix.height());
+    let size = 1 << log_n;
+    let plonky3_rou = Val::two_adic_generator(log_n);
+
+    let mut ntt_cfg: NTTConfig<'_, ScalarField> = NTTConfig::default();
+    ntt_cfg.batch_size = matrix.width() as i32;
+    ntt_cfg.columns_batch = true;
+
+    initialize_domain(ScalarField::from([plonky3_rou.as_canonical_u32()]), &ntt_cfg.ctx, true).unwrap();
+
+    let mut ntt_results = DeviceVec::<ScalarField>::cuda_malloc(matrix.values.len()).unwrap();
+    let mut host_ntt_results = vec![ScalarField::zero(); matrix.values.len()];
+    let mut actual_scalars: Vec<ScalarField> = matrix.values.iter().map(|x| ScalarField::from_u32((*x).as_canonical_u32())).collect();
+
+    //println!("p3 - size {} log_n {} matrix_p3.height {} matrix_p3.len {} matrix_p3.width {}", size, log_n, matrix.height(), matrix.values.len(), matrix.width());
+    ntt::ntt(HostSlice::from_mut_slice(&mut actual_scalars[..]), NTTDir::kForward, &ntt_cfg, &mut ntt_results[..]).unwrap();
+
+    ntt_cfg.ctx.stream.synchronize().unwrap();
+    ntt_results
+        .copy_to_host(HostSlice::from_mut_slice(&mut host_ntt_results[..]))
+        .unwrap();
+    let scalars_p3: Vec<Val> = host_ntt_results
+        .iter()
+        .map(|x| Val::from_wrapped_u32(Into::<[u32; 1]>::into(*x)[0]))
+        .collect();
+    matrix = RowMajorMatrix::new(scalars_p3, matrix.width());
+    release_domain::<ScalarField>(&ntt_cfg.ctx).unwrap();
+
+    matrix.bit_reverse_rows().to_row_major_matrix()
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -685,5 +675,7 @@ mod tests {
         */
     }
 }
+
+
 
 

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -187,15 +187,16 @@ where
                 let ctx = DeviceContext::default();
                 let size = 1 << log_n;
                 let plonky3_rou = Val::two_adic_generator(log_n);
-                initialize_domain(ScalarField::from([plonky3_rou.as_canonical_u32()]), &ntt_cfg.ctx, true).unwrap();
+            
+                let mut ntt_cfg2: NTTConfig<'_, ScalarField> = NTTConfig::default();
+                ntt_cfg2.batch_size = matrix_p3.width() as i32;
+                ntt_cfg2.columns_batch = true;
+                initialize_domain(ScalarField::from([plonky3_rou.as_canonical_u32()]), &ntt_cfg2.ctx, true).unwrap();
 
                 ntt_results = DeviceVec::<ScalarField>::cuda_malloc(matrix_p3.values.len()).unwrap();
                 host_ntt_results = vec![ScalarField::zero(); matrix_p3.values.len()];
                 actual_scalars = matrix_p3.values.iter().map(|x| ScalarField::from_u32((*x).as_canonical_u32())).collect();
-
-                let mut ntt_cfg2: NTTConfig<'_, ScalarField> = NTTConfig::default();
-                ntt_cfg2.batch_size = matrix_p3.width() as i32;
-                ntt_cfg2.columns_batch = true;
+                println!("config {:?}", ntt_cfg2);
                 println!("p3 - size {} log_n {} matrix_p3.height {} matrix_p3.len {} matrix_p3.width {}", size, log_n, matrix_p3.height(), matrix_p3.values.len(), matrix_p3.width());
                 ntt::ntt(HostSlice::from_mut_slice(&mut actual_scalars[..]), NTTDir::kForward, &ntt_cfg2, &mut ntt_results[..]).unwrap();
 


### PR DESCRIPTION
I was testing using a full run for the fibonacci example in sp1
`ubuntu@ip-172-31-65-65:~/sp1/examples/fibonacci/script$   RUST_LOG=info cargo run --bin groth16 --release`

The current state of things:

- both NTTs are performed on GPU with scaling on CPU
- the behavior for log_n=25 in second NTT seems suspicious (erroring out with ```invalid configuration argument```)  and @yuval will take a look into it.